### PR TITLE
lara_cheat: adjust initial fly position

### DIFF
--- a/src/game/lara/lara_cheat.c
+++ b/src/game/lara/lara_cheat.c
@@ -21,7 +21,7 @@ bool __cdecl Lara_Cheat_EnterFlyMode(void)
     }
 
     if (g_Lara.water_status != LWS_UNDERWATER || g_LaraItem->hit_points <= 0) {
-        g_LaraItem->pos.y -= STEP_L / 2;
+        g_LaraItem->pos.y -= STEP_L;
         g_LaraItem->current_anim_state = LS_SWIM;
         g_LaraItem->goal_anim_state = LS_SWIM;
         g_LaraItem->anim_num =


### PR DESCRIPTION
The swim collision is a bit stricter in TR2 it seems, so despite us setting the same X rot as TR1X, the value is adjusted because Lara is so close to the ground. Rather than tweaking the collision control for the sake of the fly cheat (and indeed we might want to test swim collision while flying as it would normally behave when underwater), there are two options - to raise Lara off the ground slightly more, or to reduce the X rot below 15. I opted to raise her a full click instead of a half, so the tilt remains consistent with TR1X.

![Screenshot 2024-08-30 210353](https://github.com/user-attachments/assets/a9f27d55-b854-45e4-bdb3-ff2cfd121e98)

Resolves #166.

[TR2X.zip](https://github.com/user-attachments/files/16821733/TR2X.zip)
