### PR TITLE
Add ability to remap console key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@
     - `/give`
     - `/kill`
     - `/flip`
+- added an ability to remap the console key (#163)
 - added `/tp` console command's ability to teleport to specific items
 - added `/fly` console command's ability to open nearest doors
 - added an option to fix M16 accuracy while running (#45)
 - added a .NET-based configuration tool (#197)
+- changed the default flare key from `/` to `.` to avoid conflicts with the console (#163)
 - fixed explosions sometimes being drawn too dark (#187)
 - fixed killing the T-Rex with a grenade launcher crashing the game (#168)
 - fixed secret rewards not displaying shotgun ammo (#159)

--- a/docs/progress.txt
+++ b/docs/progress.txt
@@ -1656,7 +1656,7 @@ typedef struct __unaligned {
     uint16_t key[14]; // INPUT_ROLE_NUMBER_OF
 } CONTROL_LAYOUT;
 
-typedef enum {
+typedef enum { // decompiled
     IN_FORWARD     = 0x00000001,
     IN_BACK        = 0x00000002,
     IN_LEFT        = 0x00000004,

--- a/docs/progress.txt
+++ b/docs/progress.txt
@@ -4685,7 +4685,7 @@ typedef enum {
 0x0051A250  +       int32_t g_LayoutPage;
 0x0051A24C  +       int32_t g_KeySelector;
 0x0051A248  +       int32_t g_KeyCursor;
-0x00466FA8  -       const char *g_KeyNames[];
+0x00466FA8  +       const char *g_KeyNames[];
 0x00464500  -       const uint16_t g_Requester_BackgroundGour1[];
 0x00464520  -       const uint16_t g_Requester_BackgroundGour2[];
 0x00464538  -       const uint16_t g_Requester_MainGour1[];

--- a/src/decomp/decomp.c
+++ b/src/decomp/decomp.c
@@ -3018,6 +3018,8 @@ void __cdecl S_LoadSettings(void)
 
     CloseGameRegistryKey();
 
+    Input_CheckConflictsWithDefaults();
+
     Sound_SetMasterVolume(6 * g_OptionSoundVolume + 4);
 
     if (g_OptionMusicVolume) {

--- a/src/game/console.c
+++ b/src/game/console.c
@@ -215,10 +215,6 @@ bool Console_HandleKeyDown(const uint32_t key)
 #endif
 
     switch (key) {
-    case VK_OEM_2: // TODO: make me configurable!
-        Console_Open();
-        return true;
-
     case VK_LEFT:
         if (!m_IsOpened) {
             return false;

--- a/src/game/gun/gun.c
+++ b/src/game/gun/gun.c
@@ -3,6 +3,7 @@
 #include "game/gun/gun_misc.h"
 #include "game/gun/gun_pistols.h"
 #include "game/gun/gun_rifle.h"
+#include "game/input.h"
 #include "game/inventory/backpack.h"
 #include "game/lara/lara_control.h"
 #include "game/sound.h"

--- a/src/game/gun/gun_pistols.c
+++ b/src/game/gun/gun_pistols.c
@@ -2,6 +2,7 @@
 
 #include "game/gun/gun.h"
 #include "game/gun/gun_misc.h"
+#include "game/input.h"
 #include "game/math.h"
 #include "game/sound.h"
 #include "global/funcs.h"

--- a/src/game/gun/gun_rifle.c
+++ b/src/game/gun/gun_rifle.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "game/gun/gun.h"
 #include "game/gun/gun_misc.h"
+#include "game/input.h"
 #include "game/items.h"
 #include "game/lara/lara_misc.h"
 #include "game/math.h"

--- a/src/game/input.c
+++ b/src/game/input.c
@@ -45,10 +45,17 @@ static const char *m_KeyNames[] = {
 };
 
 bool g_ConflictLayout[INPUT_ROLE_NUMBER_OF] = { false };
+bool m_ListenMode = false;
 
 bool Input_Update(void)
 {
     bool result = S_Input_Update();
+
+    if (m_ListenMode) {
+        g_Input = 0;
+        g_InputDB = 0;
+        return true;
+    }
 
     g_InputDB = Input_GetDebounced(g_Input);
 
@@ -141,4 +148,14 @@ void __cdecl Input_CheckConflictsWithDefaults(void)
             }
         }
     }
+}
+
+void Input_EnterListenMode(void)
+{
+    m_ListenMode = true;
+}
+
+void Input_ExitListenMode(void)
+{
+    m_ListenMode = false;
 }

--- a/src/game/input.c
+++ b/src/game/input.c
@@ -49,7 +49,9 @@ bool g_ConflictLayout[INPUT_ROLE_NUMBER_OF] = { false };
 bool Input_Update(void)
 {
     bool result = S_Input_Update();
+
     g_InputDB = Input_GetDebounced(g_Input);
+
     if (Console_IsOpened()) {
         if (g_InputDB & IN_DESELECT) {
             Console_Close();
@@ -59,7 +61,12 @@ bool Input_Update(void)
 
         g_Input = 0;
         g_InputDB = 0;
+    } else if (g_InputDB & IN_CONSOLE) {
+        Console_Open();
+        g_Input = 0;
+        g_InputDB = 0;
     }
+
     return result;
 }
 
@@ -110,6 +117,7 @@ const char *Input_GetRoleName(const INPUT_ROLE role)
     case INPUT_ROLE_LOOK:        return g_GF_GameStrings[GF_S_GAME_KEYMAP_LOOK];
     case INPUT_ROLE_ROLL:        return g_GF_GameStrings[GF_S_GAME_KEYMAP_ROLL];
     case INPUT_ROLE_OPTION:      return g_GF_GameStrings[GF_S_GAME_KEYMAP_INVENTORY];
+    case INPUT_ROLE_CONSOLE:     return "Console";
     default:                     return "";
     }
     // clang-format on

--- a/src/game/input.c
+++ b/src/game/input.c
@@ -127,3 +127,18 @@ const char *Input_GetKeyName(const uint16_t key)
 {
     return m_KeyNames[key];
 }
+
+void __cdecl Input_CheckConflictsWithDefaults(void)
+{
+    for (int32_t i = 0; i < INPUT_ROLE_NUMBER_OF; i++) {
+        g_ConflictLayout[i] = false;
+        for (int32_t j = 0; j < INPUT_ROLE_NUMBER_OF; j++) {
+            const uint16_t key1 = Input_GetAssignedKey(0, i);
+            const uint16_t key2 = Input_GetAssignedKey(1, j);
+            if (key1 == key2) {
+                g_ConflictLayout[i] = true;
+                break;
+            }
+        }
+    }
+}

--- a/src/game/input.c
+++ b/src/game/input.c
@@ -5,6 +5,45 @@
 #include "global/vars.h"
 #include "specific/s_input.h"
 
+#include <libtrx/log.h>
+
+static const char *m_KeyNames[] = {
+    NULL,   "ESC",   "1",     "2",     "3",     "4",     "5",     "6",
+    "7",    "8",     "9",     "0",     "-",     "+",     "BKSP",  "TAB",
+    "Q",    "W",     "E",     "R",     "T",     "Y",     "U",     "I",
+    "O",    "P",     "<",     ">",     "RET",   "CTRL",  "A",     "S",
+    "D",    "F",     "G",     "H",     "J",     "K",     "L",     ";",
+    "'",    "`",     "SHIFT", "#",     "Z",     "X",     "C",     "V",
+    "B",    "N",     "M",     ",",     ".",     "/",     "SHIFT", "PADx",
+    "ALT",  "SPACE", "CAPS",  NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    "NMLK",  NULL,    "PAD7",
+    "PAD8", "PAD9",  "PAD-",  "PAD4",  "PAD5",  "PAD6",  "PAD+",  "PAD1",
+    "PAD2", "PAD3",  "PAD0",  "PAD.",  NULL,    NULL,    "\\",    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    "ENTER", "CTRL",  NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    "SHIFT", NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    "PAD/",  NULL,    NULL,
+    "ALT",  NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    "HOME",
+    "UP",   "PGUP",  NULL,    "LEFT",  NULL,    "RIGHT", NULL,    "END",
+    "DOWN", "PGDN",  "INS",   "DEL",   NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    NULL,   NULL,    NULL,    NULL,    NULL,    NULL,    NULL,    NULL,
+    "JOY1", "JOY2",  "JOY3",  "JOY4",  "JOY5",  "JOY6",  "JOY7",  "JOY8",
+    "JOY9", "JOY10", "JOY11", "JOY12", "JOY13", "JOY14", "JOY15", "JOY16",
+};
+
 bool g_ConflictLayout[INPUT_ROLE_NUMBER_OF] = { false };
 
 bool Input_Update(void)
@@ -78,5 +117,5 @@ const char *Input_GetRoleName(const INPUT_ROLE role)
 
 const char *Input_GetKeyName(const uint16_t key)
 {
-    return g_KeyNames[key];
+    return m_KeyNames[key];
 }

--- a/src/game/input.h
+++ b/src/game/input.h
@@ -22,9 +22,40 @@ typedef enum {
     INPUT_ROLE_LOOK        = 11,
     INPUT_ROLE_ROLL        = 12,
     INPUT_ROLE_OPTION      = 13,
-    INPUT_ROLE_NUMBER_OF   = 14,
+    INPUT_ROLE_CONSOLE     = 14,
+    INPUT_ROLE_NUMBER_OF   = 15,
     // clang-format on
 } INPUT_ROLE;
+
+typedef enum {
+    // clang-format off
+    IN_FORWARD     = 1 << 0,
+    IN_BACK        = 1 << 1,
+    IN_LEFT        = 1 << 2,
+    IN_RIGHT       = 1 << 3,
+    IN_JUMP        = 1 << 4,
+    IN_DRAW        = 1 << 5,
+    IN_ACTION      = 1 << 6,
+    IN_SLOW        = 1 << 7,
+    IN_OPTION      = 1 << 8,
+    IN_LOOK        = 1 << 9,
+    IN_STEP_LEFT   = 1 << 10,
+    IN_STEP_RIGHT  = 1 << 11,
+    IN_ROLL        = 1 << 12,
+    IN_PAUSE       = 1 << 13,
+    IN_RESERVED1   = 1 << 14,
+    IN_RESERVED2   = 1 << 15,
+    IN_DOZY_CHEAT  = 1 << 16,
+    IN_STUFF_CHEAT = 1 << 17,
+    IN_DEBUG_INFO  = 1 << 18,
+    IN_FLARE       = 1 << 19,
+    IN_SELECT      = 1 << 20,
+    IN_DESELECT    = 1 << 21,
+    IN_SAVE        = 1 << 22,
+    IN_LOAD        = 1 << 23,
+    IN_CONSOLE     = 1 << 24,
+    // clang-format on
+} INPUT_STATE;
 
 typedef struct {
     uint16_t key[INPUT_ROLE_NUMBER_OF];

--- a/src/game/input.h
+++ b/src/game/input.h
@@ -67,6 +67,9 @@ extern bool g_ConflictLayout[INPUT_ROLE_NUMBER_OF];
 bool Input_Update(void);
 int32_t __cdecl Input_GetDebounced(int32_t input);
 
+void Input_EnterListenMode(void);
+void Input_ExitListenMode(void);
+bool Input_IsAnythingPressed(void);
 void Input_AssignKey(int32_t layout, INPUT_ROLE role, uint16_t key);
 uint16_t Input_GetAssignedKey(int32_t layout, INPUT_ROLE role);
 

--- a/src/game/input.h
+++ b/src/game/input.h
@@ -73,3 +73,5 @@ uint16_t Input_GetAssignedKey(int32_t layout, INPUT_ROLE role);
 const char *Input_GetLayoutName(int32_t layout);
 const char *Input_GetRoleName(INPUT_ROLE role);
 const char *Input_GetKeyName(uint16_t key);
+
+void __cdecl Input_CheckConflictsWithDefaults(void);

--- a/src/game/inventory/common.c
+++ b/src/game/inventory/common.c
@@ -656,6 +656,7 @@ int32_t __cdecl Inv_Display(int32_t inventory_mode)
 
                 if (!busy && !g_Inv_IsOptionsDelay) {
                     Option_DoInventory(inv_item);
+
                     if (g_InputDB & IN_DESELECT) {
                         inv_item->sprite_list = NULL;
                         Inv_Ring_MotionSetup(

--- a/src/game/lara/lara_col.c
+++ b/src/game/lara/lara_col.c
@@ -1,6 +1,7 @@
 #include "game/lara/lara_col.h"
 
 #include "game/collide.h"
+#include "game/input.h"
 #include "game/items.h"
 #include "game/lara/lara_control.h"
 #include "game/lara/lara_misc.h"

--- a/src/game/lara/lara_control.c
+++ b/src/game/lara/lara_control.c
@@ -2,6 +2,7 @@
 
 #include "game/creature.h"
 #include "game/gun/gun.h"
+#include "game/input.h"
 #include "game/inventory/backpack.h"
 #include "game/items.h"
 #include "game/lara/lara_cheat.h"

--- a/src/game/lara/lara_look.c
+++ b/src/game/lara/lara_look.c
@@ -1,5 +1,6 @@
 #include "game/lara/lara_look.h"
 
+#include "game/input.h"
 #include "global/const.h"
 #include "global/vars.h"
 

--- a/src/game/lara/lara_misc.c
+++ b/src/game/lara/lara_misc.c
@@ -3,6 +3,7 @@
 #include "decomp/decomp.h"
 #include "game/box.h"
 #include "game/collide.h"
+#include "game/input.h"
 #include "game/items.h"
 #include "game/lara/lara_control.h"
 #include "game/math.h"

--- a/src/game/lara/lara_state.c
+++ b/src/game/lara/lara_state.c
@@ -1,5 +1,6 @@
 #include "game/lara/lara_state.h"
 
+#include "game/input.h"
 #include "game/inventory/backpack.h"
 #include "game/lara/lara_control.h"
 #include "game/lara/lara_look.h"

--- a/src/game/objects/vehicles/boat.c
+++ b/src/game/objects/vehicles/boat.c
@@ -2,6 +2,7 @@
 
 #include "decomp/effects.h"
 #include "game/effects.h"
+#include "game/input.h"
 #include "game/items.h"
 #include "game/lara/lara_look.h"
 #include "game/math.h"

--- a/src/game/option/option.c
+++ b/src/game/option/option.c
@@ -1,5 +1,6 @@
 #include "game/option/option.h"
 
+#include "game/input.h"
 #include "global/funcs.h"
 #include "global/vars.h"
 

--- a/src/game/option/option_compass.c
+++ b/src/game/option/option_compass.c
@@ -1,4 +1,5 @@
 #include "decomp/stats.h"
+#include "game/input.h"
 #include "game/option/option.h"
 #include "game/requester.h"
 #include "game/sound.h"

--- a/src/game/option/option_controls.c
+++ b/src/game/option/option_controls.c
@@ -9,8 +9,10 @@ static UI_CONTROLS_CONTROLLER m_ControlsDialogController;
 
 void Option_Controls_Shutdown(void)
 {
-    m_ControlsDialog->free(m_ControlsDialog);
-    m_ControlsDialog = NULL;
+    if (m_ControlsDialog != NULL) {
+        m_ControlsDialog->free(m_ControlsDialog);
+        m_ControlsDialog = NULL;
+    }
     Input_CheckConflictsWithDefaults();
 }
 

--- a/src/game/option/option_controls.c
+++ b/src/game/option/option_controls.c
@@ -7,25 +7,11 @@
 static UI_WIDGET *m_ControlsDialog;
 static UI_CONTROLS_CONTROLLER m_ControlsDialogController;
 
-void __cdecl Option_Controls_DefaultConflict(void)
-{
-    for (int32_t i = 0; i < INPUT_ROLE_NUMBER_OF; i++) {
-        g_ConflictLayout[i] = false;
-        for (int32_t j = 0; j < INPUT_ROLE_NUMBER_OF; j++) {
-            const uint16_t key1 = Input_GetAssignedKey(0, i);
-            const uint16_t key2 = Input_GetAssignedKey(1, j);
-            if (key1 == key2) {
-                g_ConflictLayout[i] = true;
-            }
-        }
-    }
-}
-
 void Option_Controls_Shutdown(void)
 {
     m_ControlsDialog->free(m_ControlsDialog);
     m_ControlsDialog = NULL;
-    Option_Controls_DefaultConflict();
+    Input_CheckConflictsWithDefaults();
 }
 
 void __cdecl Option_Controls(INVENTORY_ITEM *const item)

--- a/src/game/option/option_detail.c
+++ b/src/game/option/option_detail.c
@@ -1,3 +1,4 @@
+#include "game/input.h"
 #include "game/option/option.h"
 #include "game/text.h"
 #include "global/funcs.h"

--- a/src/game/option/option_passport.c
+++ b/src/game/option/option_passport.c
@@ -1,3 +1,4 @@
+#include "game/input.h"
 #include "game/option/option.h"
 #include "game/requester.h"
 #include "game/sound.h"

--- a/src/game/option/option_sound.c
+++ b/src/game/option/option_sound.c
@@ -1,3 +1,4 @@
+#include "game/input.h"
 #include "game/music.h"
 #include "game/option/option.h"
 #include "game/sound.h"

--- a/src/game/requester.c
+++ b/src/game/requester.c
@@ -1,5 +1,6 @@
 #include "game/requester.h"
 
+#include "game/input.h"
 #include "game/text.h"
 #include "global/funcs.h"
 #include "global/vars.h"

--- a/src/game/ui/controllers/controls.c
+++ b/src/game/ui/controllers/controls.c
@@ -2,6 +2,8 @@
 
 #include "global/vars.h"
 
+#include <libtrx/utils.h>
+
 #include <dinput.h>
 
 static const INPUT_ROLE m_LeftRoles[] = {
@@ -11,9 +13,9 @@ static const INPUT_ROLE m_LeftRoles[] = {
 };
 
 static const INPUT_ROLE m_RightRoles[] = {
-    INPUT_ROLE_JUMP,   INPUT_ROLE_ACTION, INPUT_ROLE_DRAW_WEAPON,
-    INPUT_ROLE_FLARE,  INPUT_ROLE_LOOK,   INPUT_ROLE_ROLL,
-    INPUT_ROLE_OPTION, (INPUT_ROLE)-1,
+    INPUT_ROLE_JUMP,   INPUT_ROLE_ACTION,  INPUT_ROLE_DRAW_WEAPON,
+    INPUT_ROLE_FLARE,  INPUT_ROLE_LOOK,    INPUT_ROLE_ROLL,
+    INPUT_ROLE_OPTION, INPUT_ROLE_CONSOLE, (INPUT_ROLE)-1,
 };
 
 static const INPUT_ROLE *UI_ControlsController_GetInputRoles(int32_t col);
@@ -67,10 +69,12 @@ static bool UI_ControlsController_NavigateInputs(
 {
     if (g_InputDB & IN_DESELECT) {
         controller->state = UI_CONTROLS_STATE_EXIT;
-    } else if (g_InputDB & IN_RIGHT) {
+    } else if (g_InputDB & (IN_LEFT | IN_RIGHT)) {
         controller->active_col ^= 1;
-    } else if (g_InputDB & IN_LEFT) {
-        controller->active_col ^= 1;
+        CLAMP(
+            controller->active_row, 0,
+            UI_ControlsController_GetInputRoleCount(controller->active_col)
+                - 1);
     } else if (g_InputDB & IN_FORWARD) {
         controller->active_row--;
         if (controller->active_row < 0) {

--- a/src/game/ui/controllers/controls.c
+++ b/src/game/ui/controllers/controls.c
@@ -143,7 +143,7 @@ static bool UI_ControlsController_Listen(
 
     if (!pressed
         // clang-format off
-        || g_KeyNames[pressed] == NULL
+        || Input_GetKeyName(pressed) == NULL
         || pressed == DIK_RETURN
         || pressed == DIK_LEFT
         || pressed == DIK_RIGHT

--- a/src/game/ui/controllers/controls.c
+++ b/src/game/ui/controllers/controls.c
@@ -1,5 +1,6 @@
 #include "game/ui/controllers/controls.h"
 
+#include "game/input.h"
 #include "global/vars.h"
 
 #include <libtrx/utils.h>
@@ -110,9 +111,10 @@ static bool UI_ControlsController_NavigateInputs(
 static bool UI_ControlsController_ListenDebounce(
     UI_CONTROLS_CONTROLLER *const controller)
 {
-    if (g_Input) {
+    if (Input_IsAnythingPressed()) {
         return false;
     }
+    Input_EnterListenMode();
     controller->state = UI_CONTROLS_STATE_LISTEN;
     return true;
 }
@@ -172,9 +174,11 @@ static bool UI_ControlsController_Listen(
 static bool UI_ControlsController_NavigateInputsDebounce(
     UI_CONTROLS_CONTROLLER *const controller)
 {
-    if (g_Input) {
+    if (Input_IsAnythingPressed()) {
         return false;
     }
+
+    Input_ExitListenMode();
     controller->state = UI_CONTROLS_STATE_NAVIGATE_INPUTS;
     return true;
 }

--- a/src/game/ui/controls_input_selector.c
+++ b/src/game/ui/controls_input_selector.c
@@ -30,7 +30,11 @@ static void UI_ControlsInputSelector_UpdateText(
 {
     const uint16_t key =
         Input_GetAssignedKey(self->controller->active_layout, self->input_role);
-    UI_Label_ChangeText(self->choice, Input_GetKeyName(key));
+    if (Input_GetKeyName(key) == NULL) {
+        UI_Label_ChangeText(self->choice, "BAD");
+    } else {
+        UI_Label_ChangeText(self->choice, Input_GetKeyName(key));
+    }
     UI_Label_ChangeText(self->label, Input_GetRoleName(self->input_role));
 }
 
@@ -69,6 +73,7 @@ static void UI_ControlsInputSelector_Control(
             UI_Label_AddFrame(self->choice);
         }
     }
+
     UI_ControlsInputSelector_UpdateText(self);
 
     // Flash conflicts

--- a/src/global/types.h
+++ b/src/global/types.h
@@ -1606,33 +1606,6 @@ typedef struct __unaligned {
 } CONTROL_LAYOUT;
 
 typedef enum {
-    IN_FORWARD     = 0x00000001,
-    IN_BACK        = 0x00000002,
-    IN_LEFT        = 0x00000004,
-    IN_RIGHT       = 0x00000008,
-    IN_JUMP        = 0x00000010,
-    IN_DRAW        = 0x00000020,
-    IN_ACTION      = 0x00000040,
-    IN_SLOW        = 0x00000080,
-    IN_OPTION      = 0x00000100,
-    IN_LOOK        = 0x00000200,
-    IN_STEP_LEFT   = 0x00000400,
-    IN_STEP_RIGHT  = 0x00000800,
-    IN_ROLL        = 0x00001000,
-    IN_PAUSE       = 0x00002000,
-    IN_RESERVED1   = 0x00004000,
-    IN_RESERVED2   = 0x00008000,
-    IN_DOZY_CHEAT  = 0x00010000,
-    IN_STUFF_CHEAT = 0x00020000,
-    IN_DEBUG_INFO  = 0x00040000,
-    IN_FLARE       = 0x00080000,
-    IN_SELECT      = 0x00100000,
-    IN_DESELECT    = 0x00200000,
-    IN_SAVE        = 0x00400000,
-    IN_LOAD        = 0x00800000,
-} INPUT_STATE;
-
-typedef enum {
     LA_RUN                                   = 0,
     LA_WALK_FORWARD                          = 1,
     LA_WALK_STOP_RIGHT                       = 2,

--- a/src/inject_exec.c
+++ b/src/inject_exec.c
@@ -384,7 +384,6 @@ static void Inject_Option(const bool enable)
     INJECT(enable, 0x0044F520, Option_Detail);
     INJECT(enable, 0x0044F800, Option_Sound);
     INJECT(enable, 0x0044FCA0, Option_Compass);
-    INJECT(enable, 0x0044FDE0, Option_Controls_DefaultConflict);
     INJECT(enable, 0x0044FE20, Option_Controls);
 }
 

--- a/src/specific/s_input.c
+++ b/src/specific/s_input.c
@@ -499,3 +499,13 @@ bool __cdecl S_Input_Update(void)
     g_Input = input;
     return g_IsGameToExit;
 }
+
+bool Input_IsAnythingPressed(void)
+{
+    for (int32_t i = 0; i < 256; i++) {
+        if (KEY_DOWN(i)) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/specific/s_input.c
+++ b/src/specific/s_input.c
@@ -27,10 +27,11 @@ INPUT_LAYOUT g_Layout[2] = {
         DIK_RMENU,
         DIK_RCONTROL,
         DIK_SPACE,
-        DIK_SLASH,
+        DIK_PERIOD,
         DIK_NUMPAD0,
         DIK_END,
         DIK_ESCAPE,
+        DIK_SLASH,
     } },
     { .key = {
         DIK_NUMPAD8,
@@ -47,6 +48,7 @@ INPUT_LAYOUT g_Layout[2] = {
         DIK_NUMPAD0,
         DIK_NUMPAD5,
         DIK_DECIMAL,
+        DIK_SLASH,
     } }
 };
 
@@ -164,6 +166,10 @@ bool __cdecl S_Input_Update(void)
     }
     if (S_Input_Key(INPUT_ROLE_ROLL)) {
         input |= IN_ROLL;
+    }
+
+    if (S_Input_Key(INPUT_ROLE_CONSOLE)) {
+        input |= IN_CONSOLE;
     }
 
     if (S_Input_Key(INPUT_ROLE_OPTION) && g_Camera.type != CAM_CINEMATIC) {


### PR DESCRIPTION
- Changes the way the console key has been handled until now, to work like other ingame keys. In practice, this means for example that pressing `/` during demos should no longer be a roulette and should always spawn the console. 
- Changes the flare button default binding to `.` to avoid conflicts with the console button.
- Fixes reusing default keys in an user layout (#228).