### PR TITLE
room_draw: check for outside flag when setting room bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - fixed pulling the dagger from the dragon not activating triggers (#148, regression from 0.1)
 - fixed the music at the beginning of Offshore Rig not playing (#150, regression from 0.1)
 - fixed wade animation when moving from deep to shallow water (#231, regression from 0.1)
+- fixed the distorted skybox in room 5 of Barkhang Monastery (#196)
 - improved initial level load time by lazy-loading audio samples (#114)
 - improved crash debug information (#137)
 - improved the console caret sprite (#91)

--- a/src/game/room_draw.c
+++ b/src/game/room_draw.c
@@ -39,7 +39,7 @@ void __cdecl Room_GetBounds(void)
             }
         }
 
-        if (!(r->flags & RF_INSIDE)) {
+        if (!(r->flags & RF_INSIDE) || (r->flags & RF_OUTSIDE)) {
             if (r->bound_left < g_OutsideLeft) {
                 g_OutsideLeft = r->bound_left;
             }


### PR DESCRIPTION
Fixes a bug with the skybox in room 5 of  Barkhang Monastary. Resolves #196.